### PR TITLE
Add Bookmark data model and storage persistence

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,7 @@ export default [
                 clearInterval: 'readonly',
                 setTimeout: 'readonly',
                 clearTimeout: 'readonly',
+                crypto: 'readonly',
                 HTMLInputElement: 'readonly',
             },
         },

--- a/src/components/modal.test.tsx
+++ b/src/components/modal.test.tsx
@@ -18,6 +18,8 @@ const createInitialState = (): State => ({
   size: 1,
   url: 'https://netflix.com',
   controlBar: true,
+  bookmarks: [],
+  quickAccessIds: [],
 });
 
 describe('modalWithState', () => {

--- a/src/hooks/global-state.test.ts
+++ b/src/hooks/global-state.test.ts
@@ -28,6 +28,8 @@ const createInitialState = (): State => ({
   size: 1,
   url: 'https://netflix.com',
   controlBar: true,
+  bookmarks: [],
+  quickAccessIds: [],
 });
 
 describe('globalState', () => {

--- a/src/hooks/global-state.tsx
+++ b/src/hooks/global-state.tsx
@@ -1,7 +1,7 @@
 import { StateManager } from 'cotton-box';
 import { useContext, createContext } from 'react';
 
-import { Position, ViewMode } from '../lib/util';
+import { Bookmark, Position, ViewMode } from '../lib/util';
 import { useStateValue } from 'cotton-box-react';
 
 export interface State {
@@ -13,6 +13,8 @@ export interface State {
   size: number;
   url: string;
   controlBar: boolean;
+  bookmarks: Bookmark[];
+  quickAccessIds: string[];
 }
 
 export const GlobalContext = createContext(new StateManager<State>({} as State));

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -59,6 +59,9 @@ describe('plugin entrypoint', () => {
     const provider = globalComponentFactory!();
     const stateManager = provider.props.value as StateManager<Record<string, unknown>>;
 
+    const bookmarks = [{ id: 'bm-1', name: 'YouTube', url: 'https://youtube.com' }];
+    const quickAccessIds = ['bm-1'];
+
     stateManager.set({
       viewMode: 2,
       previousViewMode: 2,
@@ -67,6 +70,8 @@ describe('plugin entrypoint', () => {
       margin: 45,
       size: 1.3,
       url: 'https://example.com',
+      bookmarks,
+      quickAccessIds,
     });
 
     expect(setItemSpy).toHaveBeenCalledWith(
@@ -76,6 +81,8 @@ describe('plugin entrypoint', () => {
         margin: 45,
         size: 1.3,
         url: 'https://example.com',
+        bookmarks,
+        quickAccessIds,
       }),
     );
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,8 @@ export default definePlugin(() => {
     size: 1,
     url: 'https://netflix.com',
     controlBar: true,
+    bookmarks: [],
+    quickAccessIds: [],
   };
 
   const state = new StateManager<State>({
@@ -26,8 +28,11 @@ export default definePlugin(() => {
     ...getPersistedPortalState(localStorage),
   });
 
-  state.watch(({ position, margin, size, url }) =>
-    localStorage.setItem(PORTAL_STORAGE_KEY, JSON.stringify({ position, margin, size, url })),
+  state.watch(({ position, margin, size, url, bookmarks, quickAccessIds }) =>
+    localStorage.setItem(
+      PORTAL_STORAGE_KEY,
+      JSON.stringify({ position, margin, size, url, bookmarks, quickAccessIds }),
+    ),
   );
 
   routerHook.addGlobalComponent('Portal', () => {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -35,4 +35,42 @@ describe('portal storage', () => {
 
     expect(persisted).toEqual({});
   });
+
+  it('round-trips bookmarks and quickAccessIds', () => {
+    const storage = createLocalStorageMock();
+    const portalData = {
+      position: 'TopRight',
+      margin: 30,
+      size: 1,
+      url: 'https://netflix.com',
+      bookmarks: [
+        { id: 'bm-1', name: 'YouTube', url: 'https://youtube.com' },
+        { id: 'bm-2', name: 'Twitch', url: 'https://twitch.tv' },
+      ],
+      quickAccessIds: ['bm-1', 'bm-2'],
+    };
+    storage.setItem(PORTAL_STORAGE_KEY, JSON.stringify(portalData));
+
+    const persisted = getPersistedPortalState(storage);
+
+    expect(persisted.bookmarks).toEqual(portalData.bookmarks);
+    expect(persisted.quickAccessIds).toEqual(portalData.quickAccessIds);
+  });
+
+  it('tolerates persisted payloads missing bookmark fields', () => {
+    const storage = createLocalStorageMock();
+    const portalData = {
+      position: 'TopRight',
+      margin: 30,
+      size: 1,
+      url: 'https://netflix.com',
+    };
+    storage.setItem(PORTAL_STORAGE_KEY, JSON.stringify(portalData));
+
+    const persisted = getPersistedPortalState(storage);
+
+    expect(persisted).toEqual(portalData);
+    expect(persisted).not.toHaveProperty('bookmarks');
+    expect(persisted).not.toHaveProperty('quickAccessIds');
+  });
 });

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  createBookmark,
+  generateBookmarkId,
   PICTURE_HEIGHT,
   PICTURE_WIDTH,
   Position,
@@ -8,6 +10,8 @@ import {
   SCREEN_WIDTH,
   ViewMode,
 } from './util';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 describe('util constants and enums', () => {
   it('exports expected screen constants', () => {
@@ -36,5 +40,41 @@ describe('util constants and enums', () => {
     expect(Position.BottomLeft).toBe(5);
     expect(Position.Left).toBe(6);
     expect(Position.TopLeft).toBe(7);
+  });
+});
+
+describe('bookmark helpers', () => {
+  it('generateBookmarkId returns a non-empty string', () => {
+    const id = generateBookmarkId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('generateBookmarkId returns a UUID v4', () => {
+    expect(generateBookmarkId()).toMatch(UUID_V4_REGEX);
+  });
+
+  it('generateBookmarkId produces distinct values on successive calls', () => {
+    const ids = new Set(Array.from({ length: 10 }, () => generateBookmarkId()));
+    expect(ids.size).toBe(10);
+  });
+
+  it('createBookmark returns a bookmark with the provided name and url', () => {
+    const bookmark = createBookmark('YouTube', 'https://youtube.com');
+    expect(bookmark.name).toBe('YouTube');
+    expect(bookmark.url).toBe('https://youtube.com');
+    expect(bookmark.id).toMatch(UUID_V4_REGEX);
+  });
+
+  it('createBookmark does not populate icon fields', () => {
+    const bookmark = createBookmark('YouTube', 'https://youtube.com');
+    expect(bookmark.iconUrl).toBeUndefined();
+    expect(bookmark.iconDataUrl).toBeUndefined();
+  });
+
+  it('createBookmark produces distinct ids for each call', () => {
+    const a = createBookmark('A', 'https://a.example');
+    const b = createBookmark('B', 'https://b.example');
+    expect(a.id).not.toBe(b.id);
   });
 });

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -20,3 +20,19 @@ export enum Position {
   Left,
   TopLeft,
 }
+
+export interface Bookmark {
+  id: string;
+  name: string;
+  url: string;
+  iconUrl?: string;
+  iconDataUrl?: string;
+}
+
+export const generateBookmarkId = (): string => crypto.randomUUID();
+
+export const createBookmark = (name: string, url: string): Bookmark => ({
+  id: generateBookmarkId(),
+  name,
+  url,
+});


### PR DESCRIPTION
Introduces the data foundation for the bookmarks feature (issue #15):
a Bookmark interface (id, name, url, plus optional iconUrl/iconDataUrl
reserved for favicon caching in a follow-up), bookmarks and
quickAccessIds on the global State, and round-trip persistence through
the existing portal localStorage key.