### PR TITLE
Seed default bookmarks on first launch (#16)

### DIFF
--- a/docs/features/BOOKMARKS.md
+++ b/docs/features/BOOKMARKS.md
@@ -45,7 +45,6 @@ Give users a fast, touch-friendly way to save websites they visit often and laun
   - Twitch
   - Netflix
   - Crunchyroll
-  - Disney+
 - Users can delete or modify these freely.
 
 ---

--- a/src/components/modal.test.tsx
+++ b/src/components/modal.test.tsx
@@ -20,6 +20,7 @@ const createInitialState = (): State => ({
   controlBar: true,
   bookmarks: [],
   quickAccessIds: [],
+  bookmarksInitialised: false,
 });
 
 describe('modalWithState', () => {

--- a/src/hooks/global-state.test.ts
+++ b/src/hooks/global-state.test.ts
@@ -30,6 +30,7 @@ const createInitialState = (): State => ({
   controlBar: true,
   bookmarks: [],
   quickAccessIds: [],
+  bookmarksInitialised: false,
 });
 
 describe('globalState', () => {

--- a/src/hooks/global-state.tsx
+++ b/src/hooks/global-state.tsx
@@ -15,6 +15,7 @@ export interface State {
   controlBar: boolean;
   bookmarks: Bookmark[];
   quickAccessIds: string[];
+  bookmarksInitialised: boolean;
 }
 
 export const GlobalContext = createContext(new StateManager<State>({} as State));

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -72,6 +72,7 @@ describe('plugin entrypoint', () => {
       url: 'https://example.com',
       bookmarks,
       quickAccessIds,
+      bookmarksInitialised: true,
     });
 
     expect(setItemSpy).toHaveBeenCalledWith(
@@ -83,6 +84,7 @@ describe('plugin entrypoint', () => {
         url: 'https://example.com',
         bookmarks,
         quickAccessIds,
+        bookmarksInitialised: true,
       }),
     );
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { Settings } from './components/settings';
 import { Position, ViewMode } from './lib/util';
 import { State, GlobalContext } from './hooks/global-state';
 import { getPersistedPortalState, PORTAL_STORAGE_KEY } from './lib/storage';
+import { seedIfNeeded } from './lib/default-bookmarks';
 
 export default definePlugin(() => {
   const defaultState: State = {
@@ -21,17 +22,26 @@ export default definePlugin(() => {
     controlBar: true,
     bookmarks: [],
     quickAccessIds: [],
+    bookmarksInitialised: false,
   };
 
   const state = new StateManager<State>({
     ...defaultState,
-    ...getPersistedPortalState(localStorage),
+    ...seedIfNeeded(getPersistedPortalState(localStorage)),
   });
 
-  state.watch(({ position, margin, size, url, bookmarks, quickAccessIds }) =>
+  state.watch(({ position, margin, size, url, bookmarks, quickAccessIds, bookmarksInitialised }) =>
     localStorage.setItem(
       PORTAL_STORAGE_KEY,
-      JSON.stringify({ position, margin, size, url, bookmarks, quickAccessIds }),
+      JSON.stringify({
+        position,
+        margin,
+        size,
+        url,
+        bookmarks,
+        quickAccessIds,
+        bookmarksInitialised,
+      }),
     ),
   );
 

--- a/src/lib/default-bookmarks.test.ts
+++ b/src/lib/default-bookmarks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { Bookmark } from './util';
+import { DEFAULT_BOOKMARKS, seedIfNeeded } from './default-bookmarks';
+
+describe('DEFAULT_BOOKMARKS', () => {
+  it('contains the four expected defaults in order', () => {
+    expect(DEFAULT_BOOKMARKS.map((b) => b.name)).toEqual([
+      'YouTube',
+      'Twitch',
+      'Netflix',
+      'Crunchyroll',
+    ]);
+  });
+
+  it('uses stable slug ids prefixed with "default-"', () => {
+    for (const b of DEFAULT_BOOKMARKS) {
+      expect(b.id).toMatch(/^default-[a-z]+$/);
+    }
+    const ids = DEFAULT_BOOKMARKS.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('populates an iconUrl from the Google s2 favicon service for every default', () => {
+    for (const b of DEFAULT_BOOKMARKS) {
+      expect(b.iconUrl).toMatch(/^https:\/\/www\.google\.com\/s2\/favicons\?domain=[^&]+&sz=64$/);
+    }
+  });
+
+  it('does not populate iconDataUrl at seed time', () => {
+    for (const b of DEFAULT_BOOKMARKS) {
+      expect(b.iconDataUrl).toBeUndefined();
+    }
+  });
+});
+
+describe('seedIfNeeded', () => {
+  it('seeds defaults when no persisted state exists', () => {
+    const result = seedIfNeeded({});
+
+    expect(result.bookmarks).toBe(DEFAULT_BOOKMARKS);
+    expect(result.quickAccessIds).toEqual(DEFAULT_BOOKMARKS.map((b) => b.id));
+    expect(result.bookmarksInitialised).toBe(true);
+  });
+
+  it('preserves other persisted fields when seeding', () => {
+    const result = seedIfNeeded({ url: 'https://example.com', margin: 42 });
+
+    expect(result.url).toBe('https://example.com');
+    expect(result.margin).toBe(42);
+    expect(result.bookmarksInitialised).toBe(true);
+  });
+
+  it('does not re-seed when bookmarksInitialised is true and bookmarks were deleted', () => {
+    const persisted = { bookmarksInitialised: true, bookmarks: [], quickAccessIds: [] };
+
+    const result = seedIfNeeded(persisted);
+
+    expect(result).toBe(persisted);
+    expect(result.bookmarks).toEqual([]);
+    expect(result.quickAccessIds).toEqual([]);
+  });
+
+  it('does not overwrite existing bookmarks when flag is set', () => {
+    const existing: Bookmark[] = [{ id: 'user-1', name: 'Mine', url: 'https://mine.example' }];
+    const persisted = {
+      bookmarksInitialised: true,
+      bookmarks: existing,
+      quickAccessIds: ['user-1'],
+    };
+
+    const result = seedIfNeeded(persisted);
+
+    expect(result.bookmarks).toBe(existing);
+    expect(result.quickAccessIds).toEqual(['user-1']);
+  });
+
+  it('treats legacy persisted bookmarks (no flag) as already initialised', () => {
+    const existing: Bookmark[] = [{ id: 'user-1', name: 'Mine', url: 'https://mine.example' }];
+    const persisted = { bookmarks: existing, quickAccessIds: ['user-1'] };
+
+    const result = seedIfNeeded(persisted);
+
+    expect(result.bookmarks).toBe(existing);
+    expect(result.quickAccessIds).toEqual(['user-1']);
+    expect(result.bookmarksInitialised).toBeUndefined();
+  });
+});

--- a/src/lib/default-bookmarks.ts
+++ b/src/lib/default-bookmarks.ts
@@ -1,0 +1,43 @@
+import { Bookmark } from './util';
+import { State } from '../hooks/global-state';
+
+const favicon = (host: string) => `https://www.google.com/s2/favicons?domain=${host}&sz=64`;
+
+export const DEFAULT_BOOKMARKS: Bookmark[] = [
+  {
+    id: 'default-youtube',
+    name: 'YouTube',
+    url: 'https://www.youtube.com',
+    iconUrl: favicon('youtube.com'),
+  },
+  {
+    id: 'default-twitch',
+    name: 'Twitch',
+    url: 'https://www.twitch.tv',
+    iconUrl: favicon('twitch.tv'),
+  },
+  {
+    id: 'default-netflix',
+    name: 'Netflix',
+    url: 'https://www.netflix.com',
+    iconUrl: favicon('netflix.com'),
+  },
+  {
+    id: 'default-crunchyroll',
+    name: 'Crunchyroll',
+    url: 'https://www.crunchyroll.com',
+    iconUrl: favicon('crunchyroll.com'),
+  },
+];
+
+export const seedIfNeeded = (persisted: Partial<State>): Partial<State> => {
+  if (persisted.bookmarksInitialised || (persisted.bookmarks?.length ?? 0) > 0) {
+    return persisted;
+  }
+  return {
+    ...persisted,
+    bookmarks: DEFAULT_BOOKMARKS,
+    quickAccessIds: DEFAULT_BOOKMARKS.map((b) => b.id),
+    bookmarksInitialised: true,
+  };
+};


### PR DESCRIPTION
Adds YouTube, Twitch, Netflix, and Crunchyroll as default bookmarks that
populate the bookmarks list and all four quick-access slots when the plugin
is launched without any prior bookmark data.

- `DEFAULT_BOOKMARKS` uses stable slug ids (`default-<name>`) and populates
  `iconUrl` from Google's s2 favicon service so the UI has something to
  render before the icon caching story (#22) ships.
- `seedIfNeeded` is a pure helper that returns the patched `Partial<State>`
  and is guarded by a new `bookmarksInitialised` flag. The flag is also
  persisted by the existing state watcher so once the user deletes all
  defaults we never resurrect them. Pre-#16 persisted state that already
  has bookmarks is treated as initialised to avoid clobbering user data
  on upgrade.
- Docs updated to match the shipped 4-default set (drop Disney+).

https://claude.ai/code/session_01NMFWQmguHz8oXvHe4kwbLu