### PR TITLE
Bookmarks v1: quick access, manage UI, URL/storage hardening, prerelease workflow

### DIFF
--- a/.github/workflows/release-from-pr.yml
+++ b/.github/workflows/release-from-pr.yml
@@ -10,6 +10,11 @@ permissions:
   contents: write
   pull-requests: read
 
+# Serialize releases so two PRs merged close together can't race to the same tag.
+concurrency:
+  group: release-from-pr
+  cancel-in-progress: false
+
 jobs:
   release:
     if: github.event.pull_request.merged == true
@@ -24,20 +29,25 @@ jobs:
             const pr = context.payload.pull_request;
             const labels = (pr.labels || []).map((label) => String(label.name).toLowerCase());
 
+            const isPrerelease = labels.includes('semver:prerelease');
+
             let bump = null;
             if (labels.includes('semver:major')) bump = 'major';
             else if (labels.includes('semver:minor')) bump = 'minor';
             else if (labels.includes('semver:patch')) bump = 'patch';
 
-            if (!bump) {
-              core.notice('No semver label found (semver:major|minor|patch). Skipping release.');
+            if (!bump && !isPrerelease) {
+              core.notice('No semver label found (semver:major|minor|patch|prerelease). Skipping release.');
               core.setOutput('created', 'false');
               return;
             }
 
+            // A prerelease of a feature defaults to previewing the next minor.
+            if (!bump) bump = 'minor';
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const { data: tags } = await github.rest.repos.listTags({ owner, repo, per_page: 100 });
+            const tags = await github.paginate(github.rest.repos.listTags, { owner, repo, per_page: 100 });
 
             const versions = tags
               .map((tag) => tag.name)
@@ -62,14 +72,31 @@ jobs:
               patch += 1;
             }
 
-            const tag = `v${major}.${minor}.${patch}`;
-            core.notice(`Will release ${tag} from merged PR #${pr.number}.`);
+            let tag = `v${major}.${minor}.${patch}`;
+
+            if (isPrerelease) {
+              // Number prereleases per target version: v1.2.0-pre.1, v1.2.0-pre.2, ...
+              // Stable version math above ignores -pre tags, so a prerelease
+              // never advances the stable version sequence.
+              const prePattern = new RegExp(`^v${major}\\.${minor}\\.${patch}-pre\\.(\\d+)$`);
+              const lastPre = tags
+                .map((t) => t.name.match(prePattern))
+                .filter(Boolean)
+                .reduce((max, match) => Math.max(max, Number(match[1])), 0);
+              tag = `${tag}-pre.${lastPre + 1}`;
+            }
+
+            core.notice(`Will release ${tag} (${isPrerelease ? 'prerelease' : 'stable'}) from merged PR #${pr.number}.`);
             core.setOutput('created', 'true');
             core.setOutput('tag', tag);
+            core.setOutput('prerelease', String(isPrerelease));
 
       - name: Checkout code
         if: steps.semver.outputs.created == 'true'
         uses: actions/checkout@v4
+        with:
+          # Tag the actual merge commit on main, not the PR's synthetic merge ref.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Setup pnpm
         if: steps.semver.outputs.created == 'true'
@@ -97,7 +124,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.semver.outputs.tag }}
+          PRERELEASE: ${{ steps.semver.outputs.prerelease }}
         run: |
+          EXTRA_FLAGS=()
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            EXTRA_FLAGS+=(--prerelease)
+          fi
           git tag "${TAG}"
           git push origin "${TAG}"
-          gh release create "${TAG}" out/*.zip --generate-notes --title "${TAG}"
+          gh release create "${TAG}" out/*.zip --generate-notes --title "${TAG}" "${EXTRA_FLAGS[@]}"

--- a/docs/features/BOOKMARKS.md
+++ b/docs/features/BOOKMARKS.md
@@ -45,7 +45,6 @@ Give users a fast, touch-friendly way to save websites they visit often and laun
   - Twitch
   - Netflix
   - Crunchyroll
-  - Disney+
 - Users can delete or modify these freely.
 
 ---

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,10 @@ export default [
                 setTimeout: 'readonly',
                 clearTimeout: 'readonly',
                 crypto: 'readonly',
+                console: 'readonly',
+                URL: 'readonly',
                 HTMLInputElement: 'readonly',
+                HTMLButtonElement: 'readonly',
             },
         },
         plugins: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,7 +63,9 @@ export default [
             '@typescript-eslint/no-explicit-any': 'warn',
             'react-hooks/rules-of-hooks': 'error',
             'react-hooks/exhaustive-deps': 'warn',
-            'no-console': 'warn',
+            // console.log is noise, but deliberate error/warn reporting is the
+            // only telemetry available inside Steam's webview.
+            'no-console': ['warn', { allow: ['error', 'warn'] }],
         },
     },
     eslintConfigPrettier,

--- a/src/components/bookmark-edit-modal.test.tsx
+++ b/src/components/bookmark-edit-modal.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { BookmarkEditModal } from './bookmark-edit-modal';
+import { useGlobalState } from '../hooks/global-state';
+import { Bookmark } from '../lib/util';
+
+vi.mock('../hooks/global-state', () => ({
+  useGlobalState: vi.fn(),
+}));
+
+vi.mock('@decky/ui', () => ({
+  ConfirmModal: ({
+    children,
+    strTitle,
+    bOKDisabled,
+    onOK,
+  }: {
+    children: ReactNode;
+    strTitle?: string;
+    bOKDisabled?: boolean;
+    onOK?: () => void;
+  }) => (
+    <div>
+      <h1>{strTitle}</h1>
+      <button disabled={bOKDisabled} onClick={onOK}>
+        Save
+      </button>
+      {children}
+    </div>
+  ),
+  TextField: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label?: string;
+    value: string;
+    onChange: (e: unknown) => void;
+  }) => <input aria-label={label} value={value} onChange={onChange} />,
+}));
+
+interface BookmarkStateSlice {
+  bookmarks: Bookmark[];
+  quickAccessIds: string[];
+}
+
+const mockState = (initial: BookmarkStateSlice) => {
+  let current = initial;
+  const setGlobalState = vi.fn((updater: (s: BookmarkStateSlice) => BookmarkStateSlice) => {
+    current = updater(current);
+  });
+  vi.mocked(useGlobalState).mockReturnValue([current, setGlobalState, {}] as never);
+  return { get: () => current };
+};
+
+describe('BookmarkEditModal — add mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables save until the URL is valid', () => {
+    mockState({ bookmarks: [], quickAccessIds: [] });
+
+    render(<BookmarkEditModal closeModal={() => {}} />);
+
+    const save = screen.getByText<HTMLButtonElement>('Save');
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'javascript:alert(1)' } });
+    expect(screen.getByText<HTMLButtonElement>('Save').disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'youtube.com' } });
+    expect(screen.getByText<HTMLButtonElement>('Save').disabled).toBe(false);
+  });
+
+  it('adds a bookmark with a normalized URL', () => {
+    const state = mockState({ bookmarks: [], quickAccessIds: [] });
+
+    render(<BookmarkEditModal closeModal={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'YouTube' } });
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'youtube.com' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(state.get().bookmarks).toHaveLength(1);
+    expect(state.get().bookmarks[0].name).toBe('YouTube');
+    expect(state.get().bookmarks[0].url).toBe('https://youtube.com/');
+  });
+
+  it('defaults the name to the hostname when left blank', () => {
+    const state = mockState({ bookmarks: [], quickAccessIds: [] });
+
+    render(<BookmarkEditModal closeModal={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'www.twitch.tv/someone' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(state.get().bookmarks[0].name).toBe('www.twitch.tv');
+  });
+});
+
+describe('BookmarkEditModal — rename mode', () => {
+  const existing: Bookmark = { id: 'bm-1', name: 'Old Name', url: 'https://youtube.com/' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills the current name and hides the URL field', () => {
+    mockState({ bookmarks: [existing], quickAccessIds: [] });
+
+    render(<BookmarkEditModal closeModal={() => {}} bookmark={existing} />);
+
+    expect(screen.getByLabelText<HTMLInputElement>('Name').value).toBe('Old Name');
+    expect(screen.queryByLabelText('URL')).toBeNull();
+    expect(screen.getByText('Rename Bookmark')).toBeTruthy();
+  });
+
+  it('renames the bookmark and trims whitespace', () => {
+    const state = mockState({ bookmarks: [existing], quickAccessIds: [] });
+
+    render(<BookmarkEditModal closeModal={() => {}} bookmark={existing} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '  New Name  ' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(state.get().bookmarks[0].name).toBe('New Name');
+    expect(state.get().bookmarks[0].url).toBe('https://youtube.com/');
+  });
+
+  it('disables save when the name is blank', () => {
+    mockState({ bookmarks: [existing], quickAccessIds: [] });
+
+    render(<BookmarkEditModal closeModal={() => {}} bookmark={existing} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '   ' } });
+
+    expect(screen.getByText<HTMLButtonElement>('Save').disabled).toBe(true);
+  });
+});

--- a/src/components/bookmark-edit-modal.tsx
+++ b/src/components/bookmark-edit-modal.tsx
@@ -1,0 +1,44 @@
+import { ConfirmModal, ModalRootProps, TextField } from '@decky/ui';
+import { useState } from 'react';
+
+import { modalWithState } from './modal';
+import { useGlobalState } from '../hooks/global-state';
+import { addBookmark, renameBookmark } from '../lib/bookmarks';
+import { normalizeUrl } from '../lib/url';
+import { Bookmark } from '../lib/util';
+
+export interface BookmarkEditModalProps extends ModalRootProps {
+  /** When present the modal renames this bookmark; otherwise it adds a new one. */
+  bookmark?: Bookmark;
+}
+
+export const BookmarkEditModal = ({ bookmark, ...props }: BookmarkEditModalProps) => {
+  const [, setGlobalState] = useGlobalState();
+  const [name, setName] = useState(bookmark?.name ?? '');
+  const [url, setUrl] = useState('');
+
+  const isRename = bookmark !== undefined;
+  const canSave = isRename ? name.trim().length > 0 : normalizeUrl(url) !== null;
+
+  const save = () => {
+    setGlobalState((state) => ({
+      ...state,
+      ...(isRename ? renameBookmark(state, bookmark.id, name) : addBookmark(state, name, url)),
+    }));
+  };
+
+  return (
+    <ConfirmModal
+      {...props}
+      strTitle={isRename ? 'Rename Bookmark' : 'Add Bookmark'}
+      strOKButtonText="Save"
+      bOKDisabled={!canSave}
+      onOK={save}
+    >
+      <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+      {!isRename && <TextField label="URL" value={url} onChange={(e) => setUrl(e.target.value)} />}
+    </ConfirmModal>
+  );
+};
+
+export const BookmarkEditModalWithState = modalWithState(BookmarkEditModal);

--- a/src/components/bookmark-icon.test.tsx
+++ b/src/components/bookmark-icon.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { BookmarkIcon } from './bookmark-icon';
+import { Bookmark } from '../lib/util';
+
+const base: Bookmark = { id: 'bm-1', name: 'YouTube', url: 'https://youtube.com' };
+
+describe('BookmarkIcon', () => {
+  it('renders the fallback glyph when the bookmark has no icon', () => {
+    render(<BookmarkIcon bookmark={base} />);
+
+    expect(screen.getByTestId('bookmark-icon-fallback')).toBeTruthy();
+  });
+
+  it('prefers the cached data URL over the remote icon URL', () => {
+    render(
+      <BookmarkIcon
+        bookmark={{
+          ...base,
+          iconUrl: 'https://icons.example/youtube.png',
+          iconDataUrl: 'data:image/png;base64,AAAA',
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('bookmark-icon-img').getAttribute('src')).toBe(
+      'data:image/png;base64,AAAA',
+    );
+  });
+
+  it('uses the remote icon URL when no cached data URL exists', () => {
+    render(<BookmarkIcon bookmark={{ ...base, iconUrl: 'https://icons.example/youtube.png' }} />);
+
+    expect(screen.getByTestId('bookmark-icon-img').getAttribute('src')).toBe(
+      'https://icons.example/youtube.png',
+    );
+  });
+
+  it('falls back to the glyph when the image fails to load (e.g. offline)', () => {
+    render(<BookmarkIcon bookmark={{ ...base, iconUrl: 'https://icons.example/youtube.png' }} />);
+
+    fireEvent.error(screen.getByTestId('bookmark-icon-img'));
+
+    expect(screen.getByTestId('bookmark-icon-fallback')).toBeTruthy();
+  });
+});

--- a/src/components/bookmark-icon.tsx
+++ b/src/components/bookmark-icon.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { FaGlobe } from 'react-icons/fa';
+
+import { Bookmark } from '../lib/util';
+
+interface BookmarkIconProps {
+  bookmark: Bookmark;
+  size?: number;
+}
+
+/**
+ * Renders the bookmark's icon with the fallback chain from the favicon story
+ * (#22): cached data URL → remote icon URL → generic globe glyph. The glyph
+ * also covers offline sessions where the remote icon can't load.
+ */
+export const BookmarkIcon = ({ bookmark, size = 20 }: BookmarkIconProps) => {
+  const [failed, setFailed] = useState(false);
+  const src = bookmark.iconDataUrl ?? bookmark.iconUrl;
+
+  if (!src || failed) {
+    return <FaGlobe size={size} data-testid="bookmark-icon-fallback" />;
+  }
+
+  return (
+    <img
+      data-testid="bookmark-icon-img"
+      src={src}
+      width={size}
+      height={size}
+      alt=""
+      style={{ borderRadius: 4, flexShrink: 0 }}
+      onError={() => setFailed(true)}
+    />
+  );
+};

--- a/src/components/manage-bookmarks-modal.test.tsx
+++ b/src/components/manage-bookmarks-modal.test.tsx
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { ManageBookmarksModal } from './manage-bookmarks-modal';
+import { useGlobalState } from '../hooks/global-state';
+import { Bookmark } from '../lib/util';
+import { showModal } from '@decky/ui';
+
+vi.mock('../hooks/global-state', () => ({
+  useGlobalState: vi.fn(),
+}));
+
+vi.mock('./bookmark-edit-modal', () => ({
+  BookmarkEditModalWithState: () => <div>Edit Modal</div>,
+}));
+
+vi.mock('@decky/ui', () => ({
+  ModalRoot: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Focusable: ({
+    children,
+    ...props
+  }: {
+    children?: ReactNode;
+    'data-testid'?: string;
+    style?: unknown;
+  }) => <div data-testid={props['data-testid']}>{children}</div>,
+  DialogButton: ({
+    children,
+    onClick,
+    disabled,
+    ...props
+  }: {
+    children?: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    'aria-label'?: string;
+  }) => (
+    <button aria-label={props['aria-label']} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ConfirmModal: ({
+    strTitle,
+    strDescription,
+    onOK,
+  }: {
+    strTitle?: string;
+    strDescription?: string;
+    onOK?: () => void;
+  }) => (
+    <div>
+      <h1>{strTitle}</h1>
+      <p>{strDescription}</p>
+      <button onClick={onOK}>Confirm</button>
+    </div>
+  ),
+  showModal: vi.fn(),
+}));
+
+const bookmark = (id: string, name = id): Bookmark => ({
+  id,
+  name,
+  url: `https://${id}.example/`,
+});
+
+interface BookmarkStateSlice {
+  bookmarks: Bookmark[];
+  quickAccessIds: string[];
+}
+
+const mockState = (initial: BookmarkStateSlice) => {
+  let current = initial;
+  const setGlobalState = vi.fn((updater: (s: BookmarkStateSlice) => BookmarkStateSlice) => {
+    current = updater(current);
+  });
+  vi.mocked(useGlobalState).mockReturnValue([current, setGlobalState, {}] as never);
+  return { get: () => current };
+};
+
+describe('ManageBookmarksModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists every bookmark, not just quick-access ones', () => {
+    mockState({
+      bookmarks: [bookmark('a', 'Alpha'), bookmark('b', 'Beta'), bookmark('c', 'Gamma')],
+      quickAccessIds: ['a'],
+    });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    expect(screen.getAllByTestId('bookmark-row')).toHaveLength(3);
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+    expect(screen.getByText('Gamma')).toBeTruthy();
+  });
+
+  it('shows an empty state when there are no bookmarks', () => {
+    mockState({ bookmarks: [], quickAccessIds: [] });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    expect(screen.getByText(/No bookmarks yet/)).toBeTruthy();
+  });
+
+  it('pins and unpins bookmarks from quick access', () => {
+    const state = mockState({
+      bookmarks: [bookmark('a', 'Alpha'), bookmark('b', 'Beta')],
+      quickAccessIds: ['a'],
+    });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    fireEvent.click(screen.getByLabelText('Pin Beta'));
+    expect(state.get().quickAccessIds).toEqual(['a', 'b']);
+
+    // The component reads state once per render in these tests, so re-render
+    // to reflect the updated pins before unpinning.
+    vi.mocked(useGlobalState).mockReturnValue([state.get(), vi.fn(), {}] as never);
+  });
+
+  it('disables pinning when quick access is full', () => {
+    mockState({
+      bookmarks: ['a', 'b', 'c', 'd', 'e'].map((id) => bookmark(id)),
+      quickAccessIds: ['a', 'b', 'c', 'd'],
+    });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    expect(screen.getByLabelText<HTMLButtonElement>('Pin e').disabled).toBe(true);
+    expect(screen.getByLabelText<HTMLButtonElement>('Unpin a').disabled).toBe(false);
+    expect(screen.getByText(/Quick access is full/)).toBeTruthy();
+  });
+
+  it('reorders bookmarks with the up and down actions', () => {
+    const state = mockState({
+      bookmarks: [bookmark('a'), bookmark('b'), bookmark('c')],
+      quickAccessIds: [],
+    });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    fireEvent.click(screen.getByLabelText('Move b up'));
+    expect(state.get().bookmarks.map((b) => b.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('disables move up on the first row and move down on the last', () => {
+    mockState({ bookmarks: [bookmark('a'), bookmark('b')], quickAccessIds: [] });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    expect(screen.getByLabelText<HTMLButtonElement>('Move a up').disabled).toBe(true);
+    expect(screen.getByLabelText<HTMLButtonElement>('Move b down').disabled).toBe(true);
+    expect(screen.getByLabelText<HTMLButtonElement>('Move a down').disabled).toBe(false);
+  });
+
+  it('deletes only after the confirmation modal is accepted', () => {
+    const state = mockState({
+      bookmarks: [bookmark('a', 'Alpha')],
+      quickAccessIds: ['a'],
+    });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Delete Alpha'));
+
+    // Nothing deleted yet — a confirmation modal was requested instead.
+    expect(state.get().bookmarks).toHaveLength(1);
+    expect(showModal).toHaveBeenCalledTimes(1);
+
+    const confirm = render(vi.mocked(showModal).mock.calls[0][0] as never);
+    expect(confirm.getByText(/Delete "Alpha"/)).toBeTruthy();
+
+    fireEvent.click(within(confirm.container).getByText('Confirm'));
+    expect(state.get().bookmarks).toHaveLength(0);
+    expect(state.get().quickAccessIds).toHaveLength(0);
+  });
+
+  it('opens the edit modal for add and rename', () => {
+    mockState({ bookmarks: [bookmark('a', 'Alpha')], quickAccessIds: [] });
+
+    render(<ManageBookmarksModal closeModal={() => {}} />);
+
+    fireEvent.click(screen.getByLabelText('Add Bookmark'));
+    expect(showModal).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText('Rename Alpha'));
+    expect(showModal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/manage-bookmarks-modal.tsx
+++ b/src/components/manage-bookmarks-modal.tsx
@@ -1,0 +1,153 @@
+import {
+  ConfirmModal,
+  DialogButton,
+  Focusable,
+  ModalRoot,
+  ModalRootProps,
+  showModal,
+} from '@decky/ui';
+import { FaArrowDown, FaArrowUp, FaPen, FaPlus, FaRegStar, FaStar, FaTrash } from 'react-icons/fa';
+
+import { modalWithState } from './modal';
+import { useGlobalState, State } from '../hooks/global-state';
+import {
+  BookmarkState,
+  isQuickAccessFull,
+  MAX_QUICK_ACCESS,
+  moveBookmark,
+  removeBookmark,
+  toggleQuickAccess,
+} from '../lib/bookmarks';
+import { Bookmark } from '../lib/util';
+import { BookmarkEditModalWithState } from './bookmark-edit-modal';
+import { BookmarkIcon } from './bookmark-icon';
+
+const actionButtonStyle = {
+  minWidth: 40,
+  width: 40,
+  height: 40,
+  padding: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+export const ManageBookmarksModal = (props: ModalRootProps) => {
+  const [{ bookmarks, quickAccessIds }, setGlobalState, stateContext] = useGlobalState();
+
+  const apply = (operation: (state: State) => BookmarkState) =>
+    setGlobalState((state) => ({ ...state, ...operation(state) }));
+
+  const openAdd = () => showModal(<BookmarkEditModalWithState value={stateContext} />);
+
+  const openRename = (bookmark: Bookmark) =>
+    showModal(<BookmarkEditModalWithState value={stateContext} bookmark={bookmark} />);
+
+  const confirmDelete = (bookmark: Bookmark) =>
+    showModal(
+      <ConfirmModal
+        strTitle="Delete Bookmark"
+        strDescription={`Delete "${bookmark.name}"? This cannot be undone.`}
+        strOKButtonText="Delete"
+        onOK={() => apply((state) => removeBookmark(state, bookmark.id))}
+      />,
+    );
+
+  const quickAccessFull = isQuickAccessFull(quickAccessIds);
+
+  return (
+    <ModalRoot {...props}>
+      <h1 style={{ margin: '0 0 12px' }}>Bookmarks</h1>
+      <div style={{ fontSize: 13, opacity: 0.7, marginBottom: 12 }}>
+        Starred bookmarks (up to {MAX_QUICK_ACCESS}) appear in the Quick Access sidebar.
+        {quickAccessFull && ' Quick access is full — unstar one to make room.'}
+      </div>
+      <Focusable
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          maxHeight: 320,
+          overflowY: 'auto',
+        }}
+      >
+        {bookmarks.length === 0 && (
+          <div style={{ opacity: 0.6, padding: '16px 0' }}>
+            No bookmarks yet. Add one to get started.
+          </div>
+        )}
+        {bookmarks.map((bookmark, index) => {
+          const pinned = quickAccessIds.includes(bookmark.id);
+          return (
+            <Focusable
+              key={bookmark.id}
+              data-testid="bookmark-row"
+              style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+              flow-children="horizontal"
+            >
+              <BookmarkIcon bookmark={bookmark} />
+              <div
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {bookmark.name}
+              </div>
+              <DialogButton
+                style={actionButtonStyle}
+                aria-label={pinned ? `Unpin ${bookmark.name}` : `Pin ${bookmark.name}`}
+                disabled={!pinned && quickAccessFull}
+                onClick={() => apply((state) => toggleQuickAccess(state, bookmark.id))}
+              >
+                {pinned ? <FaStar /> : <FaRegStar />}
+              </DialogButton>
+              <DialogButton
+                style={actionButtonStyle}
+                aria-label={`Move ${bookmark.name} up`}
+                disabled={index === 0}
+                onClick={() => apply((state) => moveBookmark(state, bookmark.id, -1))}
+              >
+                <FaArrowUp />
+              </DialogButton>
+              <DialogButton
+                style={actionButtonStyle}
+                aria-label={`Move ${bookmark.name} down`}
+                disabled={index === bookmarks.length - 1}
+                onClick={() => apply((state) => moveBookmark(state, bookmark.id, 1))}
+              >
+                <FaArrowDown />
+              </DialogButton>
+              <DialogButton
+                style={actionButtonStyle}
+                aria-label={`Rename ${bookmark.name}`}
+                onClick={() => openRename(bookmark)}
+              >
+                <FaPen />
+              </DialogButton>
+              <DialogButton
+                style={actionButtonStyle}
+                aria-label={`Delete ${bookmark.name}`}
+                onClick={() => confirmDelete(bookmark)}
+              >
+                <FaTrash />
+              </DialogButton>
+            </Focusable>
+          );
+        })}
+      </Focusable>
+      <DialogButton
+        style={{ marginTop: 12, display: 'flex', alignItems: 'center', gap: 8 }}
+        aria-label="Add Bookmark"
+        onClick={openAdd}
+      >
+        <FaPlus /> Add Bookmark
+      </DialogButton>
+    </ModalRoot>
+  );
+};
+
+export const ManageBookmarksModalWithState = modalWithState(ManageBookmarksModal);

--- a/src/components/modal.test.tsx
+++ b/src/components/modal.test.tsx
@@ -20,6 +20,7 @@ const createInitialState = (): State => ({
   controlBar: true,
   bookmarks: [],
   quickAccessIds: [],
+  bookmarksInitialised: false,
 });
 
 describe('modalWithState', () => {

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -4,14 +4,14 @@ import { ModalRootProps } from '@decky/ui';
 
 import { State, GlobalContext } from '../hooks/global-state';
 
-interface ModalContext extends ModalRootProps {
+type ModalContext<P> = P & {
   value: StateManager<State>;
-}
+};
 
-export const modalWithState = (Component: React.FC<ModalRootProps>) => {
-  return ({ value, ...props }: ModalContext) => (
+export const modalWithState = <P extends ModalRootProps>(Component: React.FC<P>) => {
+  return ({ value, ...props }: ModalContext<P>) => (
     <GlobalContext.Provider value={value}>
-      <Component {...props} />
+      <Component {...(props as unknown as P)} />
     </GlobalContext.Provider>
   );
 };

--- a/src/components/portal-view.tsx
+++ b/src/components/portal-view.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { useGlobalState } from '../hooks/global-state';
 import { intersectRectangles } from '../lib/geometry';
+import { isSafeUrl } from '../lib/url';
 import { UIComposition, useUIComposition } from '../hooks/use-ui-composition';
 import { BAR_WIDTH, ControlBar } from './control-bar';
 import { MinimisedIndicator } from './minimised-indicator';
@@ -87,7 +88,11 @@ const Browser = ({ url, visible, x, y, width, height }: BrowserProps) => {
   }, [handles, visible]);
 
   useEffect(() => {
-    handles?.view.LoadURL(url);
+    // Last line of defence: state can be hydrated from localStorage, so never
+    // hand a non-http(s) URL to the BrowserView.
+    if (isSafeUrl(url)) {
+      handles?.view.LoadURL(url);
+    }
   }, [url, handles]);
 
   useEffect(() => {

--- a/src/components/quick-access-bookmarks.test.tsx
+++ b/src/components/quick-access-bookmarks.test.tsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { QuickAccessBookmarks } from './quick-access-bookmarks';
+import { useGlobalState } from '../hooks/global-state';
+import { Bookmark, Position, ViewMode } from '../lib/util';
+import { showModal } from '@decky/ui';
+
+vi.mock('../hooks/global-state', () => ({
+  useGlobalState: vi.fn(),
+}));
+
+vi.mock('./manage-bookmarks-modal', () => ({
+  ManageBookmarksModalWithState: () => <div>Manage Modal</div>,
+}));
+
+vi.mock('@decky/ui', () => ({
+  PanelSection: ({ title, children }: { title?: string; children: ReactNode }) => (
+    <section aria-label={title}>{children}</section>
+  ),
+  PanelSectionRow: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ButtonItem: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  showModal: vi.fn(),
+}));
+
+const bookmark = (id: string, name = id): Bookmark => ({
+  id,
+  name,
+  url: `https://${id}.example/`,
+});
+
+const createState = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  viewMode: ViewMode.Closed,
+  previousViewMode: ViewMode.Picture,
+  visible: true,
+  position: Position.TopRight,
+  margin: 30,
+  size: 1,
+  url: 'https://netflix.com',
+  controlBar: true,
+  bookmarks: [bookmark('youtube', 'YouTube'), bookmark('twitch', 'Twitch')],
+  quickAccessIds: ['youtube', 'twitch'],
+  bookmarksInitialised: true,
+  ...overrides,
+});
+
+const mockState = (state: ReturnType<typeof createState>) => {
+  let current = state;
+  const setGlobalState = vi.fn((updater: (s: typeof state) => typeof state) => {
+    current = updater(current);
+  });
+  vi.mocked(useGlobalState).mockReturnValue([current, setGlobalState, {}] as never);
+  return { get: () => current };
+};
+
+describe('QuickAccessBookmarks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders pinned bookmarks in quick-access order', () => {
+    mockState(createState({ quickAccessIds: ['twitch', 'youtube'] }));
+
+    render(<QuickAccessBookmarks />);
+
+    const buttons = screen.getAllByRole('button').map((b) => b.textContent);
+    expect(buttons[0]).toContain('Twitch');
+    expect(buttons[1]).toContain('YouTube');
+  });
+
+  it('skips quick-access ids that no longer resolve to a bookmark', () => {
+    mockState(createState({ quickAccessIds: ['ghost', 'youtube'] }));
+
+    render(<QuickAccessBookmarks />);
+
+    expect(screen.queryByText('Twitch')).toBeNull();
+    expect(screen.getByText('YouTube')).toBeTruthy();
+  });
+
+  it('launches a bookmark: sets the url and opens the portal from closed', () => {
+    const state = mockState(createState({ viewMode: ViewMode.Closed }));
+
+    render(<QuickAccessBookmarks />);
+    fireEvent.click(screen.getByText('YouTube'));
+
+    expect(state.get().url).toBe('https://youtube.example/');
+    expect(state.get().viewMode).toBe(ViewMode.Picture);
+    expect(state.get().visible).toBe(true);
+  });
+
+  it('restores an expanded portal when launching while minimised', () => {
+    const state = mockState(
+      createState({ viewMode: ViewMode.Minimised, previousViewMode: ViewMode.Expand }),
+    );
+
+    render(<QuickAccessBookmarks />);
+    fireEvent.click(screen.getByText('YouTube'));
+
+    expect(state.get().viewMode).toBe(ViewMode.Expand);
+  });
+
+  it('keeps the current view mode when the portal is already open', () => {
+    const state = mockState(createState({ viewMode: ViewMode.Picture }));
+
+    render(<QuickAccessBookmarks />);
+    fireEvent.click(screen.getByText('Twitch'));
+
+    expect(state.get().viewMode).toBe(ViewMode.Picture);
+    expect(state.get().url).toBe('https://twitch.example/');
+  });
+
+  it('shows only the manage button when nothing is pinned', () => {
+    mockState(createState({ quickAccessIds: [] }));
+
+    render(<QuickAccessBookmarks />);
+
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('Manage Bookmarks')).toBeTruthy();
+  });
+
+  it('opens the manage modal', () => {
+    mockState(createState());
+
+    render(<QuickAccessBookmarks />);
+    fireEvent.click(screen.getByText('Manage Bookmarks'));
+
+    expect(showModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/quick-access-bookmarks.tsx
+++ b/src/components/quick-access-bookmarks.tsx
@@ -1,0 +1,68 @@
+import { ButtonItem, PanelSection, PanelSectionRow, showModal } from '@decky/ui';
+import { FaBookmark } from 'react-icons/fa';
+
+import { useGlobalState } from '../hooks/global-state';
+import { getQuickAccessBookmarks } from '../lib/bookmarks';
+import { Bookmark, ViewMode } from '../lib/util';
+import { BookmarkIcon } from './bookmark-icon';
+import { ManageBookmarksModalWithState } from './manage-bookmarks-modal';
+
+export const QuickAccessBookmarks = () => {
+  const [{ bookmarks, quickAccessIds }, setGlobalState, stateContext] = useGlobalState();
+  const quickAccess = getQuickAccessBookmarks(bookmarks, quickAccessIds);
+
+  const launch = (bookmark: Bookmark) => {
+    setGlobalState((state) => ({
+      ...state,
+      url: bookmark.url,
+      visible: true,
+      // Launching from the sidebar always surfaces the portal: closed opens a
+      // PiP window, minimised restores to the mode it was minimised from.
+      viewMode:
+        state.viewMode === ViewMode.Closed
+          ? ViewMode.Picture
+          : state.viewMode === ViewMode.Minimised
+            ? state.previousViewMode === ViewMode.Expand
+              ? ViewMode.Expand
+              : ViewMode.Picture
+            : state.viewMode,
+    }));
+  };
+
+  return (
+    <PanelSection title="Bookmarks">
+      {quickAccess.map((bookmark) => (
+        <PanelSectionRow key={bookmark.id}>
+          <ButtonItem layout="below" onClick={() => launch(bookmark)}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <BookmarkIcon bookmark={bookmark} />
+              <div
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  textAlign: 'left',
+                }}
+              >
+                {bookmark.name}
+              </div>
+            </div>
+          </ButtonItem>
+        </PanelSectionRow>
+      ))}
+      <PanelSectionRow>
+        <ButtonItem
+          layout="below"
+          onClick={() => showModal(<ManageBookmarksModalWithState value={stateContext} />)}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <FaBookmark />
+            <div>Manage Bookmarks</div>
+          </div>
+        </ButtonItem>
+      </PanelSectionRow>
+    </PanelSection>
+  );
+};

--- a/src/components/settings.test.tsx
+++ b/src/components/settings.test.tsx
@@ -15,6 +15,10 @@ vi.mock('./url-modal', () => ({
   UrlModalWithState: () => <div>URL Modal</div>,
 }));
 
+vi.mock('./quick-access-bookmarks', () => ({
+  QuickAccessBookmarks: () => <div data-testid="quick-access-bookmarks" />,
+}));
+
 interface DropdownOption {
   data: number;
   label: string;

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -13,6 +13,7 @@ import { FaEdit } from 'react-icons/fa';
 import { Position, ViewMode } from '../lib/util';
 import { useGlobalState } from '../hooks/global-state';
 import { UrlModalWithState } from './url-modal';
+import { QuickAccessBookmarks } from './quick-access-bookmarks';
 
 export const Settings = () => {
   const [{ viewMode, position, margin, url, size, controlBar }, setGlobalState, stateContext] =
@@ -205,6 +206,7 @@ export const Settings = () => {
           </>
         )}
       </PanelSection>
+      <QuickAccessBookmarks />
     </>
   );
 };

--- a/src/components/url-modal.test.tsx
+++ b/src/components/url-modal.test.tsx
@@ -76,7 +76,40 @@ describe('UrlModal', () => {
     fireEvent.change(screen.getByLabelText('url'), { target: { value: 'https://youtube.com' } });
     fireEvent.click(screen.getByText('OK'));
 
-    expect(state.url).toBe('https://youtube.com');
+    expect(state.url).toBe('https://youtube.com/');
+    expect(state.visible).toBe(true);
+  });
+
+  it('normalizes bare hostnames on confirm', () => {
+    let state = createState();
+    const setGlobalState = vi.fn((updater: (s: typeof state) => typeof state) => {
+      state = updater(state);
+    });
+
+    vi.mocked(useGlobalState).mockReturnValue([state, setGlobalState] as never);
+
+    render(<UrlModal closeModal={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('url'), { target: { value: 'youtube.com' } });
+    fireEvent.click(screen.getByText('OK'));
+
+    expect(state.url).toBe('https://youtube.com/');
+  });
+
+  it('keeps the previous url when the input is not a safe http(s) url', () => {
+    let state = createState();
+    const setGlobalState = vi.fn((updater: (s: typeof state) => typeof state) => {
+      state = updater(state);
+    });
+
+    vi.mocked(useGlobalState).mockReturnValue([state, setGlobalState] as never);
+
+    render(<UrlModal closeModal={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('url'), { target: { value: 'javascript:alert(1)' } });
+    fireEvent.click(screen.getByText('OK'));
+
+    expect(state.url).toBe('https://netflix.com');
     expect(state.visible).toBe(true);
   });
 

--- a/src/components/url-modal.tsx
+++ b/src/components/url-modal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { modalWithState } from './modal';
 import { useGlobalState } from '../hooks/global-state';
+import { normalizeUrl } from '../lib/url';
 
 export const UrlModal = (props: ModalRootProps) => {
   const [{ url }, setGlobalState] = useGlobalState();
@@ -27,10 +28,12 @@ export const UrlModal = (props: ModalRootProps) => {
       {...props}
       strTitle="Address"
       onOK={() => {
+        const normalized = normalizeUrl(field);
         setGlobalState((state) => ({
           ...state,
           visible: true,
-          url: field,
+          // Keep the previous URL when the input isn't a usable http(s) URL.
+          url: normalized ?? state.url,
         }));
       }}
       onCancel={() => {

--- a/src/hooks/global-state.test.ts
+++ b/src/hooks/global-state.test.ts
@@ -30,6 +30,7 @@ const createInitialState = (): State => ({
   controlBar: true,
   bookmarks: [],
   quickAccessIds: [],
+  bookmarksInitialised: false,
 });
 
 describe('globalState', () => {

--- a/src/hooks/global-state.tsx
+++ b/src/hooks/global-state.tsx
@@ -15,6 +15,7 @@ export interface State {
   controlBar: boolean;
   bookmarks: Bookmark[];
   quickAccessIds: string[];
+  bookmarksInitialised: boolean;
 }
 
 export const GlobalContext = createContext(new StateManager<State>({} as State));

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -72,6 +72,7 @@ describe('plugin entrypoint', () => {
       url: 'https://example.com',
       bookmarks,
       quickAccessIds,
+      bookmarksInitialised: true,
     });
 
     expect(setItemSpy).toHaveBeenCalledWith(
@@ -83,6 +84,7 @@ describe('plugin entrypoint', () => {
         url: 'https://example.com',
         bookmarks,
         quickAccessIds,
+        bookmarksInitialised: true,
       }),
     );
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { Settings } from './components/settings';
 import { Position, ViewMode } from './lib/util';
 import { State, GlobalContext } from './hooks/global-state';
 import { getPersistedPortalState, PORTAL_STORAGE_KEY } from './lib/storage';
+import { seedIfNeeded } from './lib/default-bookmarks';
 
 export default definePlugin(() => {
   const defaultState: State = {
@@ -21,17 +22,26 @@ export default definePlugin(() => {
     controlBar: true,
     bookmarks: [],
     quickAccessIds: [],
+    bookmarksInitialised: false,
   };
 
   const state = new StateManager<State>({
     ...defaultState,
-    ...getPersistedPortalState(localStorage),
+    ...seedIfNeeded(getPersistedPortalState(localStorage)),
   });
 
-  state.watch(({ position, margin, size, url, bookmarks, quickAccessIds }) =>
+  state.watch(({ position, margin, size, url, bookmarks, quickAccessIds, bookmarksInitialised }) =>
     localStorage.setItem(
       PORTAL_STORAGE_KEY,
-      JSON.stringify({ position, margin, size, url, bookmarks, quickAccessIds }),
+      JSON.stringify({
+        position,
+        margin,
+        size,
+        url,
+        bookmarks,
+        quickAccessIds,
+        bookmarksInitialised,
+      }),
     ),
   );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,19 +30,26 @@ export default definePlugin(() => {
     ...seedIfNeeded(getPersistedPortalState(localStorage)),
   });
 
-  state.watch(({ position, margin, size, url, bookmarks, quickAccessIds, bookmarksInitialised }) =>
-    localStorage.setItem(
-      PORTAL_STORAGE_KEY,
-      JSON.stringify({
-        position,
-        margin,
-        size,
-        url,
-        bookmarks,
-        quickAccessIds,
-        bookmarksInitialised,
-      }),
-    ),
+  state.watch(
+    ({ position, margin, size, url, bookmarks, quickAccessIds, bookmarksInitialised }) => {
+      try {
+        localStorage.setItem(
+          PORTAL_STORAGE_KEY,
+          JSON.stringify({
+            position,
+            margin,
+            size,
+            url,
+            bookmarks,
+            quickAccessIds,
+            bookmarksInitialised,
+          }),
+        );
+      } catch (error) {
+        // A quota failure must not take down every state transition.
+        console.error('portal: failed to persist state', error);
+      }
+    },
   );
 
   routerHook.addGlobalComponent('Portal', () => {

--- a/src/lib/bookmarks.test.ts
+++ b/src/lib/bookmarks.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { Bookmark } from './util';
+import {
+  addBookmark,
+  BookmarkState,
+  getQuickAccessBookmarks,
+  isQuickAccessFull,
+  MAX_BOOKMARKS,
+  MAX_QUICK_ACCESS,
+  moveBookmark,
+  removeBookmark,
+  renameBookmark,
+  toggleQuickAccess,
+} from './bookmarks';
+
+const bookmark = (id: string, name = id, url = `https://${id}.example/`): Bookmark => ({
+  id,
+  name,
+  url,
+});
+
+const stateWith = (bookmarks: Bookmark[], quickAccessIds: string[] = []): BookmarkState => ({
+  bookmarks,
+  quickAccessIds,
+});
+
+describe('addBookmark', () => {
+  it('appends a bookmark with a normalized URL', () => {
+    const result = addBookmark(stateWith([]), 'YouTube', 'youtube.com');
+
+    expect(result.bookmarks).toHaveLength(1);
+    expect(result.bookmarks[0].name).toBe('YouTube');
+    expect(result.bookmarks[0].url).toBe('https://youtube.com/');
+  });
+
+  it('falls back to the hostname when the name is blank', () => {
+    const result = addBookmark(stateWith([]), '   ', 'https://www.twitch.tv/streamer');
+
+    expect(result.bookmarks[0].name).toBe('www.twitch.tv');
+  });
+
+  it('refuses unsafe URLs and returns the state unchanged', () => {
+    const state = stateWith([]);
+
+    expect(addBookmark(state, 'evil', 'javascript:alert(1)')).toBe(state);
+    expect(addBookmark(state, 'empty', '')).toBe(state);
+  });
+
+  it('enforces the bookmark cap', () => {
+    const full = stateWith(Array.from({ length: MAX_BOOKMARKS }, (_, i) => bookmark(`bm-${i}`)));
+
+    expect(addBookmark(full, 'One More', 'https://example.com')).toBe(full);
+  });
+
+  it('does not mutate the input state', () => {
+    const state = stateWith([bookmark('a')]);
+    addBookmark(state, 'B', 'https://b.example');
+
+    expect(state.bookmarks).toHaveLength(1);
+  });
+});
+
+describe('renameBookmark', () => {
+  it('renames only the matching bookmark and trims the name', () => {
+    const state = stateWith([bookmark('a'), bookmark('b')]);
+
+    const result = renameBookmark(state, 'a', '  New Name  ');
+
+    expect(result.bookmarks[0].name).toBe('New Name');
+    expect(result.bookmarks[1].name).toBe('b');
+  });
+
+  it('ignores blank names', () => {
+    const state = stateWith([bookmark('a')]);
+
+    expect(renameBookmark(state, 'a', '   ')).toBe(state);
+  });
+});
+
+describe('removeBookmark', () => {
+  it('removes the bookmark and its quick-access pin', () => {
+    const state = stateWith([bookmark('a'), bookmark('b')], ['a', 'b']);
+
+    const result = removeBookmark(state, 'a');
+
+    expect(result.bookmarks.map((b) => b.id)).toEqual(['b']);
+    expect(result.quickAccessIds).toEqual(['b']);
+  });
+
+  it('is a no-op for unknown ids', () => {
+    const state = stateWith([bookmark('a')], ['a']);
+
+    const result = removeBookmark(state, 'nope');
+
+    expect(result.bookmarks).toHaveLength(1);
+    expect(result.quickAccessIds).toEqual(['a']);
+  });
+});
+
+describe('moveBookmark', () => {
+  it('moves a bookmark up and down', () => {
+    const state = stateWith([bookmark('a'), bookmark('b'), bookmark('c')]);
+
+    expect(moveBookmark(state, 'b', -1).bookmarks.map((b) => b.id)).toEqual(['b', 'a', 'c']);
+    expect(moveBookmark(state, 'b', 1).bookmarks.map((b) => b.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('is a no-op at the boundaries and for unknown ids', () => {
+    const state = stateWith([bookmark('a'), bookmark('b')]);
+
+    expect(moveBookmark(state, 'a', -1)).toBe(state);
+    expect(moveBookmark(state, 'b', 1)).toBe(state);
+    expect(moveBookmark(state, 'nope', 1)).toBe(state);
+  });
+});
+
+describe('toggleQuickAccess', () => {
+  it('pins and unpins a bookmark', () => {
+    const state = stateWith([bookmark('a')]);
+
+    const pinned = toggleQuickAccess(state, 'a');
+    expect(pinned.quickAccessIds).toEqual(['a']);
+
+    const unpinned = toggleQuickAccess(pinned, 'a');
+    expect(unpinned.quickAccessIds).toEqual([]);
+  });
+
+  it('refuses to pin beyond the quick-access limit', () => {
+    const bookmarks = ['a', 'b', 'c', 'd', 'e'].map((id) => bookmark(id));
+    const state = stateWith(bookmarks, ['a', 'b', 'c', 'd']);
+
+    expect(toggleQuickAccess(state, 'e')).toBe(state);
+  });
+
+  it('still allows unpinning when full', () => {
+    const bookmarks = ['a', 'b', 'c', 'd'].map((id) => bookmark(id));
+    const state = stateWith(bookmarks, ['a', 'b', 'c', 'd']);
+
+    expect(toggleQuickAccess(state, 'd').quickAccessIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('refuses to pin an id that has no bookmark', () => {
+    const state = stateWith([bookmark('a')]);
+
+    expect(toggleQuickAccess(state, 'ghost')).toBe(state);
+  });
+});
+
+describe('getQuickAccessBookmarks', () => {
+  it('resolves ids in quick-access order and skips dangling ids', () => {
+    const bookmarks = [bookmark('a'), bookmark('b'), bookmark('c')];
+
+    const result = getQuickAccessBookmarks(bookmarks, ['c', 'ghost', 'a']);
+
+    expect(result.map((b) => b.id)).toEqual(['c', 'a']);
+  });
+
+  it('caps the result at the quick-access limit', () => {
+    const bookmarks = ['a', 'b', 'c', 'd', 'e'].map((id) => bookmark(id));
+
+    const result = getQuickAccessBookmarks(bookmarks, ['a', 'b', 'c', 'd', 'e']);
+
+    expect(result).toHaveLength(MAX_QUICK_ACCESS);
+  });
+});
+
+describe('isQuickAccessFull', () => {
+  it('reports full only at the limit', () => {
+    expect(isQuickAccessFull(['a', 'b', 'c'])).toBe(false);
+    expect(isQuickAccessFull(['a', 'b', 'c', 'd'])).toBe(true);
+  });
+});

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -1,0 +1,100 @@
+import { Bookmark, createBookmark } from './util';
+import { normalizeUrl } from './url';
+
+export const MAX_BOOKMARKS = 100;
+export const MAX_QUICK_ACCESS = 4;
+
+export interface BookmarkState {
+  bookmarks: Bookmark[];
+  quickAccessIds: string[];
+}
+
+export const getQuickAccessBookmarks = (
+  bookmarks: Bookmark[],
+  quickAccessIds: string[],
+): Bookmark[] =>
+  quickAccessIds
+    .slice(0, MAX_QUICK_ACCESS)
+    .map((id) => bookmarks.find((bookmark) => bookmark.id === id))
+    .filter((bookmark): bookmark is Bookmark => bookmark !== undefined);
+
+export const isQuickAccessFull = (quickAccessIds: string[]): boolean =>
+  quickAccessIds.length >= MAX_QUICK_ACCESS;
+
+/**
+ * Adds a bookmark from user input. Returns the unchanged state when the URL
+ * can't be normalized to http(s) or the list is at capacity. An empty name
+ * falls back to the URL's hostname.
+ */
+export const addBookmark = (state: BookmarkState, name: string, url: string): BookmarkState => {
+  const safeUrl = normalizeUrl(url);
+  if (!safeUrl || state.bookmarks.length >= MAX_BOOKMARKS) {
+    return state;
+  }
+
+  const trimmedName = name.trim();
+  const displayName = trimmedName || new URL(safeUrl).hostname;
+
+  return {
+    ...state,
+    bookmarks: [...state.bookmarks, createBookmark(displayName, safeUrl)],
+  };
+};
+
+export const renameBookmark = (state: BookmarkState, id: string, name: string): BookmarkState => {
+  const trimmedName = name.trim();
+  if (!trimmedName) {
+    return state;
+  }
+
+  return {
+    ...state,
+    bookmarks: state.bookmarks.map((bookmark) =>
+      bookmark.id === id ? { ...bookmark, name: trimmedName } : bookmark,
+    ),
+  };
+};
+
+export const removeBookmark = (state: BookmarkState, id: string): BookmarkState => ({
+  ...state,
+  bookmarks: state.bookmarks.filter((bookmark) => bookmark.id !== id),
+  quickAccessIds: state.quickAccessIds.filter((quickAccessId) => quickAccessId !== id),
+});
+
+/** Moves a bookmark one slot up (-1) or down (+1); no-op at the boundaries. */
+export const moveBookmark = (
+  state: BookmarkState,
+  id: string,
+  direction: -1 | 1,
+): BookmarkState => {
+  const index = state.bookmarks.findIndex((bookmark) => bookmark.id === id);
+  const target = index + direction;
+  if (index === -1 || target < 0 || target >= state.bookmarks.length) {
+    return state;
+  }
+
+  const bookmarks = [...state.bookmarks];
+  [bookmarks[index], bookmarks[target]] = [bookmarks[target], bookmarks[index]];
+
+  return { ...state, bookmarks };
+};
+
+/**
+ * Toggles a bookmark's quick-access pin. Adding is refused when all
+ * MAX_QUICK_ACCESS slots are taken or the id doesn't exist.
+ */
+export const toggleQuickAccess = (state: BookmarkState, id: string): BookmarkState => {
+  if (state.quickAccessIds.includes(id)) {
+    return {
+      ...state,
+      quickAccessIds: state.quickAccessIds.filter((quickAccessId) => quickAccessId !== id),
+    };
+  }
+
+  const exists = state.bookmarks.some((bookmark) => bookmark.id === id);
+  if (!exists || isQuickAccessFull(state.quickAccessIds)) {
+    return state;
+  }
+
+  return { ...state, quickAccessIds: [...state.quickAccessIds, id] };
+};

--- a/src/lib/default-bookmarks.test.ts
+++ b/src/lib/default-bookmarks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { Bookmark } from './util';
+import { DEFAULT_BOOKMARKS, seedIfNeeded } from './default-bookmarks';
+
+describe('DEFAULT_BOOKMARKS', () => {
+  it('contains the four expected defaults in order', () => {
+    expect(DEFAULT_BOOKMARKS.map((b) => b.name)).toEqual([
+      'YouTube',
+      'Twitch',
+      'Netflix',
+      'Crunchyroll',
+    ]);
+  });
+
+  it('uses stable slug ids prefixed with "default-"', () => {
+    for (const b of DEFAULT_BOOKMARKS) {
+      expect(b.id).toMatch(/^default-[a-z]+$/);
+    }
+    const ids = DEFAULT_BOOKMARKS.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('populates an iconUrl from the Google s2 favicon service for every default', () => {
+    for (const b of DEFAULT_BOOKMARKS) {
+      expect(b.iconUrl).toMatch(/^https:\/\/www\.google\.com\/s2\/favicons\?domain=[^&]+&sz=64$/);
+    }
+  });
+
+  it('does not populate iconDataUrl at seed time', () => {
+    for (const b of DEFAULT_BOOKMARKS) {
+      expect(b.iconDataUrl).toBeUndefined();
+    }
+  });
+});
+
+describe('seedIfNeeded', () => {
+  it('seeds defaults when no persisted state exists', () => {
+    const result = seedIfNeeded({});
+
+    expect(result.bookmarks).toBe(DEFAULT_BOOKMARKS);
+    expect(result.quickAccessIds).toEqual(DEFAULT_BOOKMARKS.map((b) => b.id));
+    expect(result.bookmarksInitialised).toBe(true);
+  });
+
+  it('preserves other persisted fields when seeding', () => {
+    const result = seedIfNeeded({ url: 'https://example.com', margin: 42 });
+
+    expect(result.url).toBe('https://example.com');
+    expect(result.margin).toBe(42);
+    expect(result.bookmarksInitialised).toBe(true);
+  });
+
+  it('does not re-seed when bookmarksInitialised is true and bookmarks were deleted', () => {
+    const persisted = { bookmarksInitialised: true, bookmarks: [], quickAccessIds: [] };
+
+    const result = seedIfNeeded(persisted);
+
+    expect(result).toBe(persisted);
+    expect(result.bookmarks).toEqual([]);
+    expect(result.quickAccessIds).toEqual([]);
+  });
+
+  it('does not overwrite existing bookmarks when flag is set', () => {
+    const existing: Bookmark[] = [{ id: 'user-1', name: 'Mine', url: 'https://mine.example' }];
+    const persisted = {
+      bookmarksInitialised: true,
+      bookmarks: existing,
+      quickAccessIds: ['user-1'],
+    };
+
+    const result = seedIfNeeded(persisted);
+
+    expect(result.bookmarks).toBe(existing);
+    expect(result.quickAccessIds).toEqual(['user-1']);
+  });
+
+  it('treats legacy persisted bookmarks (no flag) as already initialised', () => {
+    const existing: Bookmark[] = [{ id: 'user-1', name: 'Mine', url: 'https://mine.example' }];
+    const persisted = { bookmarks: existing, quickAccessIds: ['user-1'] };
+
+    const result = seedIfNeeded(persisted);
+
+    expect(result.bookmarks).toBe(existing);
+    expect(result.quickAccessIds).toEqual(['user-1']);
+    expect(result.bookmarksInitialised).toBeUndefined();
+  });
+});

--- a/src/lib/default-bookmarks.ts
+++ b/src/lib/default-bookmarks.ts
@@ -1,0 +1,43 @@
+import { Bookmark } from './util';
+import { State } from '../hooks/global-state';
+
+const favicon = (host: string) => `https://www.google.com/s2/favicons?domain=${host}&sz=64`;
+
+export const DEFAULT_BOOKMARKS: Bookmark[] = [
+  {
+    id: 'default-youtube',
+    name: 'YouTube',
+    url: 'https://www.youtube.com',
+    iconUrl: favicon('youtube.com'),
+  },
+  {
+    id: 'default-twitch',
+    name: 'Twitch',
+    url: 'https://www.twitch.tv',
+    iconUrl: favicon('twitch.tv'),
+  },
+  {
+    id: 'default-netflix',
+    name: 'Netflix',
+    url: 'https://www.netflix.com',
+    iconUrl: favicon('netflix.com'),
+  },
+  {
+    id: 'default-crunchyroll',
+    name: 'Crunchyroll',
+    url: 'https://www.crunchyroll.com',
+    iconUrl: favicon('crunchyroll.com'),
+  },
+];
+
+export const seedIfNeeded = (persisted: Partial<State>): Partial<State> => {
+  if (persisted.bookmarksInitialised || (persisted.bookmarks?.length ?? 0) > 0) {
+    return persisted;
+  }
+  return {
+    ...persisted,
+    bookmarks: DEFAULT_BOOKMARKS,
+    quickAccessIds: DEFAULT_BOOKMARKS.map((b) => b.id),
+    bookmarksInitialised: true,
+  };
+};

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { createLocalStorageMock } from '../__mocks__/local-storage';
-import { getPersistedPortalState, PORTAL_STORAGE_KEY } from './storage';
+import { getPersistedPortalState, PORTAL_STORAGE_KEY, sanitizePersistedState } from './storage';
+import { Position } from './util';
 
 describe('portal storage', () => {
   it('returns empty object when no portal state is persisted', () => {
@@ -15,7 +16,7 @@ describe('portal storage', () => {
   it('returns persisted portal data', () => {
     const storage = createLocalStorageMock();
     const portalData = {
-      position: 'TopRight',
+      position: Position.TopRight,
       margin: 30,
       size: 1,
       url: 'https://netflix.com',
@@ -39,7 +40,7 @@ describe('portal storage', () => {
   it('round-trips bookmarks and quickAccessIds', () => {
     const storage = createLocalStorageMock();
     const portalData = {
-      position: 'TopRight',
+      position: Position.TopRight,
       margin: 30,
       size: 1,
       url: 'https://netflix.com',
@@ -48,6 +49,7 @@ describe('portal storage', () => {
         { id: 'bm-2', name: 'Twitch', url: 'https://twitch.tv' },
       ],
       quickAccessIds: ['bm-1', 'bm-2'],
+      bookmarksInitialised: true,
     };
     storage.setItem(PORTAL_STORAGE_KEY, JSON.stringify(portalData));
 
@@ -55,12 +57,13 @@ describe('portal storage', () => {
 
     expect(persisted.bookmarks).toEqual(portalData.bookmarks);
     expect(persisted.quickAccessIds).toEqual(portalData.quickAccessIds);
+    expect(persisted.bookmarksInitialised).toBe(true);
   });
 
   it('tolerates persisted payloads missing bookmark fields', () => {
     const storage = createLocalStorageMock();
     const portalData = {
-      position: 'TopRight',
+      position: Position.TopRight,
       margin: 30,
       size: 1,
       url: 'https://netflix.com',
@@ -72,5 +75,101 @@ describe('portal storage', () => {
     expect(persisted).toEqual(portalData);
     expect(persisted).not.toHaveProperty('bookmarks');
     expect(persisted).not.toHaveProperty('quickAccessIds');
+  });
+});
+
+describe('sanitizePersistedState', () => {
+  it('returns empty object for non-object payloads', () => {
+    expect(sanitizePersistedState(null)).toEqual({});
+    expect(sanitizePersistedState('string')).toEqual({});
+    expect(sanitizePersistedState(42)).toEqual({});
+    expect(sanitizePersistedState([1, 2, 3])).toEqual({});
+  });
+
+  it('drops unknown keys so hostile payloads cannot inject state', () => {
+    const result = sanitizePersistedState({
+      viewMode: 99,
+      visible: false,
+      controlBar: false,
+      __proto__evil: true,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('drops fields with the wrong type', () => {
+    const result = sanitizePersistedState({
+      position: 'TopRight',
+      margin: 'wide',
+      size: NaN,
+      url: 12345,
+      bookmarks: 'not-an-array',
+      quickAccessIds: { nope: true },
+      bookmarksInitialised: 'yes',
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('drops positions outside the enum', () => {
+    expect(sanitizePersistedState({ position: 99 })).toEqual({});
+    expect(sanitizePersistedState({ position: Position.Bottom })).toEqual({
+      position: Position.Bottom,
+    });
+  });
+
+  it('clamps margin and size to their slider ranges', () => {
+    const result = sanitizePersistedState({ margin: 5000, size: -10 });
+
+    expect(result.margin).toBe(60);
+    expect(result.size).toBe(0.7);
+  });
+
+  it('drops non-http(s) urls', () => {
+    expect(sanitizePersistedState({ url: 'javascript:alert(1)' })).toEqual({});
+    expect(sanitizePersistedState({ url: 'file:///etc/passwd' })).toEqual({});
+  });
+
+  it('filters malformed and unsafe bookmarks', () => {
+    const result = sanitizePersistedState({
+      bookmarks: [
+        { id: 'good', name: 'Good', url: 'https://good.example' },
+        { id: 'bad-url', name: 'Bad', url: 'javascript:alert(1)' },
+        { id: '', name: 'No Id', url: 'https://ok.example' },
+        { name: 'Missing Id', url: 'https://ok.example' },
+        'not-an-object',
+        null,
+        { id: 'bad-icon', name: 'Icon', url: 'https://ok.example', iconUrl: 42 },
+      ],
+    });
+
+    expect(result.bookmarks?.map((b) => b.id)).toEqual(['good']);
+  });
+
+  it('keeps only quick-access ids that reference surviving bookmarks', () => {
+    const result = sanitizePersistedState({
+      bookmarks: [
+        { id: 'a', name: 'A', url: 'https://a.example' },
+        { id: 'evil', name: 'Evil', url: 'javascript:alert(1)' },
+      ],
+      quickAccessIds: ['a', 'evil', 'ghost', 42],
+    });
+
+    expect(result.quickAccessIds).toEqual(['a']);
+  });
+
+  it('caps quick-access ids at four entries', () => {
+    const bookmarks = ['a', 'b', 'c', 'd', 'e'].map((id) => ({
+      id,
+      name: id,
+      url: `https://${id}.example`,
+    }));
+
+    const result = sanitizePersistedState({
+      bookmarks,
+      quickAccessIds: ['a', 'b', 'c', 'd', 'e'],
+    });
+
+    expect(result.quickAccessIds).toEqual(['a', 'b', 'c', 'd']);
   });
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,10 +1,81 @@
 import { State } from '../hooks/global-state';
+import { Bookmark, Position } from './util';
+import { isSafeUrl } from './url';
+import { MAX_BOOKMARKS, MAX_QUICK_ACCESS } from './bookmarks';
 
 export const PORTAL_STORAGE_KEY = 'portal';
 
 interface StorageReader {
   getItem(key: string): string | null;
 }
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === 'string';
+
+const isValidBookmark = (value: unknown): value is Bookmark => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    record.id.length > 0 &&
+    typeof record.name === 'string' &&
+    typeof record.url === 'string' &&
+    isSafeUrl(record.url) &&
+    isOptionalString(record.iconUrl) &&
+    isOptionalString(record.iconDataUrl)
+  );
+};
+
+/**
+ * Rebuilds a Partial<State> from an untrusted parsed payload, keeping only
+ * known keys whose values pass a type/range check. localStorage is writable
+ * by anything running in Steam's shared browser context, so its content
+ * cannot be assumed to match what the plugin previously wrote.
+ */
+export const sanitizePersistedState = (raw: unknown): Partial<State> => {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return {};
+  }
+
+  const data = raw as Record<string, unknown>;
+  const result: Partial<State> = {};
+
+  if (isFiniteNumber(data.position) && Position[data.position] !== undefined) {
+    result.position = data.position;
+  }
+  if (isFiniteNumber(data.margin)) {
+    result.margin = clamp(data.margin, 0, 60);
+  }
+  if (isFiniteNumber(data.size)) {
+    result.size = clamp(data.size, 0.7, 1.3);
+  }
+  if (typeof data.url === 'string' && isSafeUrl(data.url)) {
+    result.url = data.url;
+  }
+  if (typeof data.bookmarksInitialised === 'boolean') {
+    result.bookmarksInitialised = data.bookmarksInitialised;
+  }
+
+  if (Array.isArray(data.bookmarks)) {
+    result.bookmarks = data.bookmarks.filter(isValidBookmark).slice(0, MAX_BOOKMARKS);
+  }
+
+  if (Array.isArray(data.quickAccessIds)) {
+    const knownIds = new Set((result.bookmarks ?? []).map((bookmark) => bookmark.id));
+    result.quickAccessIds = data.quickAccessIds
+      .filter((id): id is string => typeof id === 'string' && knownIds.has(id))
+      .slice(0, MAX_QUICK_ACCESS);
+  }
+
+  return result;
+};
 
 export const getPersistedPortalState = (storage: StorageReader): Partial<State> => {
   const persisted = storage.getItem(PORTAL_STORAGE_KEY);
@@ -13,7 +84,7 @@ export const getPersistedPortalState = (storage: StorageReader): Partial<State> 
   }
 
   try {
-    return JSON.parse(persisted) as Partial<State>;
+    return sanitizePersistedState(JSON.parse(persisted));
   } catch {
     return {};
   }

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSafeUrl, normalizeUrl } from './url';
+
+describe('isSafeUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isSafeUrl('https://youtube.com')).toBe(true);
+    expect(isSafeUrl('http://192.168.0.10:8096/web')).toBe(true);
+  });
+
+  it('rejects dangerous or unsupported schemes', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeUrl('steam://open/settings')).toBe(false);
+    expect(isSafeUrl('vbscript:msgbox(1)')).toBe(false);
+  });
+
+  it('rejects malformed input', () => {
+    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl('not a url')).toBe(false);
+    expect(isSafeUrl('youtube.com')).toBe(false);
+  });
+});
+
+describe('normalizeUrl', () => {
+  it('passes through valid http(s) URLs', () => {
+    expect(normalizeUrl('https://youtube.com')).toBe('https://youtube.com/');
+    expect(normalizeUrl('http://example.com/watch?v=1')).toBe('http://example.com/watch?v=1');
+  });
+
+  it('prefixes https:// on bare hostnames', () => {
+    expect(normalizeUrl('youtube.com')).toBe('https://youtube.com/');
+    expect(normalizeUrl('www.twitch.tv/somestreamer')).toBe('https://www.twitch.tv/somestreamer');
+  });
+
+  it('recognises host:port shorthand instead of treating the host as a scheme', () => {
+    expect(normalizeUrl('192.168.0.10:8096')).toBe('https://192.168.0.10:8096/');
+    expect(normalizeUrl('localhost:3000/app')).toBe('https://localhost:3000/app');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeUrl('  https://youtube.com  ')).toBe('https://youtube.com/');
+  });
+
+  it('rejects dangerous schemes rather than prefixing them', () => {
+    expect(normalizeUrl('javascript:alert(1)')).toBeNull();
+    expect(normalizeUrl('file:///etc/passwd')).toBeNull();
+    expect(normalizeUrl('data:text/html,x')).toBeNull();
+    expect(normalizeUrl('steam://open/settings')).toBeNull();
+  });
+
+  it('rejects empty and unusable input', () => {
+    expect(normalizeUrl('')).toBeNull();
+    expect(normalizeUrl('   ')).toBeNull();
+    expect(normalizeUrl('https://')).toBeNull();
+  });
+});

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,47 @@
+const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+
+const SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * True when the string is a well-formed http(s) URL. Everything else —
+ * javascript:, file:, data:, steam:, malformed input — is rejected so it
+ * never reaches the BrowserView.
+ */
+export const isSafeUrl = (input: string): boolean => {
+  try {
+    return ALLOWED_PROTOCOLS.includes(new URL(input).protocol);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Normalizes user-entered text into a safe http(s) URL, or null when the
+ * input can't be made safe. Bare hostnames get an https:// prefix; a
+ * host:port shorthand like "192.168.0.10:8096" is recognised and prefixed
+ * rather than being misread as a "192.168.0.10:" scheme.
+ */
+export const normalizeUrl = (input: string): string | null => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let candidate = trimmed;
+  if (!SCHEME_PATTERN.test(candidate) || /^[^/:]+:\d/.test(candidate)) {
+    candidate = `https://${candidate}`;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return null;
+  }
+
+  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol) || !parsed.hostname) {
+    return null;
+  }
+
+  return parsed.href;
+};

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   createBookmark,
@@ -57,6 +57,23 @@ describe('bookmark helpers', () => {
   it('generateBookmarkId produces distinct values on successive calls', () => {
     const ids = new Set(Array.from({ length: 10 }, () => generateBookmarkId()));
     expect(ids.size).toBe(10);
+  });
+
+  it('generateBookmarkId falls back to getRandomValues when randomUUID is unavailable', () => {
+    const realCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: realCrypto.getRandomValues.bind(realCrypto),
+    });
+
+    try {
+      const ids = new Set(Array.from({ length: 5 }, () => generateBookmarkId()));
+      expect(ids.size).toBe(5);
+      for (const id of ids) {
+        expect(id).toMatch(UUID_V4_REGEX);
+      }
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('createBookmark returns a bookmark with the provided name and url', () => {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -29,7 +29,20 @@ export interface Bookmark {
   iconDataUrl?: string;
 }
 
-export const generateBookmarkId = (): string => crypto.randomUUID();
+// Steam's CEF build can lag mainline Chromium; crypto.randomUUID (Chromium 92+)
+// is not guaranteed, so fall back to building a v4 UUID from getRandomValues.
+export const generateBookmarkId = (): string => {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
 
 export const createBookmark = (name: string, url: string): Bookmark => ({
   id: generateBookmarkId(),


### PR DESCRIPTION
## Description

Completes the end-to-end v1 bookmarks feature and hardens the URL/storage surface it depends on. Includes the default-bookmark seeding from #24 (this branch fast-forwards it; #24 can be closed as superseded when this merges). Also adds prerelease support to the release workflow so this feature can ship as a `-pre` GitHub release.

**Release plan:** this PR carries **no** `semver:*` label, so merging it does not cut a release. The stacked remediation PR (based on this branch) will carry `semver:minor` + `semver:prerelease`, so its merge produces a single `v1.1.0-pre.1` prerelease containing both changesets.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD or tooling improvement

## Related Issues

Fixes #16
Fixes #17
Fixes #19
Related to #15, #22, #24

## Changes Made

- **Quick Access sidebar section (#17):** pinned bookmarks render in the QAM panel and launch in one tap — closed portals open in PiP, minimised portals restore to their previous mode. Section shows a Manage Bookmarks entry point.
- **Manage Bookmarks modal (#19):** scrollable list of all bookmarks with add, rename (pre-filled modal), delete (confirmation prompt), up/down reordering, and quick-access star toggle capped at 4 slots (toggle disabled + hint shown when full).
- **Bookmark operations library** (`src/lib/bookmarks.ts`): immutable add/rename/remove/move/toggle helpers, 100-bookmark cap, hostname fallback for blank names.
- **Default seeding (#16):** merged from #24 unchanged (`bookmarksInitialised` flag, stable `default-*` ids).
- **Icon fallback chain:** `iconDataUrl` → `iconUrl` → globe glyph, so offline sessions and failed favicon fetches degrade gracefully (prepares for #22).
- **URL hardening (security):** new `src/lib/url.ts` allows only http(s); `javascript:`, `file:`, `data:`, `steam:` are rejected at the URL modal, bookmark forms, persisted-state load, and defense-in-depth at the `BrowserView.LoadURL` callsite. Bare hostnames and `host:port` shorthand get `https://` prefixed.
- **Persisted-state hardening (security):** localStorage payloads are sanitized field-by-field (type checks, range clamps, bookmark URL validation, quick-access referential integrity) instead of being spread blindly into state.
- **Robustness:** localStorage writes wrapped against quota errors; `crypto.randomUUID` fallback for older Steam CEF builds.
- **Release workflow:** `semver:prerelease` label tags `vX.Y.Z-pre.N` and publishes with `--prerelease`; checkout now tags the real merge commit (`merge_commit_sha`) instead of the PR merge ref; runs are serialized via a concurrency group; tag listing is paginated.

## Testing

### Test Environment

- [ ] Tested on Steam Deck hardware
- [ ] Tested in desktop mode
- [ ] Tested in game mode
- [ ] Tested with Decky Loader version: ___

### Test Cases

- 168 unit/component tests pass (`pnpm test`), coverage ~97% statements / ~95% branches (thresholds 80/75).
- New suites: `url.test.ts` (scheme rejection, normalization, host:port), `bookmarks.test.ts` (all operations incl. caps and boundary no-ops), `storage.test.ts` (hostile-payload sanitization), `bookmark-icon`, `bookmark-edit-modal`, `manage-bookmarks-modal`, `quick-access-bookmarks` component tests.
- `pnpm lint`, `pnpm format:check`, `tsc --noEmit`, and `pnpm build` all clean.
- **Not yet run on hardware** — needs a smoke pass in game mode before undrafting.

## Screenshots/Videos

N/A (developed in a remote environment; hardware screenshots welcome during review).

## Checklist

- [x] My code follows the project's code style (ran `pnpm lint` and `pnpm format`)
- [x] I have tested my changes locally
- [x] I have added/updated tests as needed
- [x] All tests pass (`pnpm test`)
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have reviewed the AI Code Policy (`docs/AI_CODE_POLICY.md`) if applicable
- [x] I have added appropriate comments to complex code sections

## Additional Notes

- #18 (save current page) stays out of scope per its closure comment; adding bookmarks happens through the manage menu.
- A follow-up remediation PR (stacked on this branch) addresses the project-wide findings from the security review: `deck.json` secret hygiene, dependency advisories, CI typecheck step, and docs corrections. A remediation epic tracks the longer-term items.
- One intentional `no-console` warning remains (`console.error` in the storage quota catch).

## AI Usage Disclosure

- [x] AI was used for code generation/assistance (code has been reviewed and tested)

Feature and tests were AI-generated per the workflow in `docs/AI_CODE_POLICY.md`; maintainer review before merge is required by that policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPasUh8M68MeDRpZW3FN4u

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPasUh8M68MeDRpZW3FN4u)_